### PR TITLE
HibernateDaoServiceImpl: workaround for nullPointerException when sms table is empty

### DIFF
--- a/src/main/java/org/esupportail/smsuapi/dao/HibernateDaoServiceImpl.java
+++ b/src/main/java/org/esupportail/smsuapi/dao/HibernateDaoServiceImpl.java
@@ -246,7 +246,7 @@ public class HibernateDaoServiceImpl extends HibernateDaoSupport
 		@SuppressWarnings("unchecked")
 		List<Integer> list = criteria.list();
 		
-		return 1 + (list.size() > 0 ? (Integer) list.get(0) : 0);
+		return 1 + (list!=null && list.size() > 0 && list.get(0) != null ? (Integer) list.get(0) : 0);
 	}
 
 	/**


### PR DESCRIPTION
Quand la table sms est vide, criteria.list() me renvoie une liste avec des éléments null ... -> j'ai un list.get(0) null qui me provoque un NullPointerException.

Java JDK de chez Sun 1.7.0_45 - j'exécute avec mvn jetty:run

Il y a peut-être (sans doute ?) mieux à faire pour régler ce problème - le patch proposé a le mérite de fonctionner cependant.
