### PR TITLE
Debug : OldISMSSender should implements ISMSSender

### DIFF
--- a/src/main/java/org/esupportail/smsuapi/services/sms/OldISMSSender.java
+++ b/src/main/java/org/esupportail/smsuapi/services/sms/OldISMSSender.java
@@ -6,7 +6,7 @@ package org.esupportail.smsuapi.services.sms;
  * @author PRQD8824
  *
  */
-public abstract class OldISMSSender {
+public abstract class OldISMSSender implements ISMSSender {
     static public class SMSBroker {
 
         /**


### PR DESCRIPTION
Sans ça et en utilisant DMC par exemple (cad pas allmysms), on récupère au lancement l'exception suivante : 
`Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type [org.esupportail.smsuapi.services.sms.ISMSSender] found for dependency: expected at least 1 bean which qualifies as autowire candidate for this dependency. Dependency annotations: {@javax.inject.Inject()}`

