### PR TITLE
REST method sending SMS designed for Apereo CAS

### DIFF
--- a/src/main/java/org/esupportail/smsuapi/services/servlet/RestServletActions.java
+++ b/src/main/java/org/esupportail/smsuapi/services/servlet/RestServletActions.java
@@ -108,7 +108,8 @@ public class RestServletActions {
 	}
 	static String getString(HttpServletRequest req, String name) {
 		String val = getString(req, name, null);
-		if(val == null && req.getServletPath() != null && req.getServletPath().endsWith("/apereo-cas")) {
+		if("action".equals(name) && val == null && req.getServletPath() != null && req.getServletPath().endsWith("/apereo-cas")) {
+			// Hack for make esup-smus-api a SMS Sender for Apereo CAS : https://apereo.github.io/cas/6.0.x/notifications/SMS-Messaging-Configuration.html#rest
 			val = "ApereoCasHandle";
 		}
 		if (val == null) throw new InvalidParameterException("\"" + name + "\" parameter is mandatory");


### PR DESCRIPTION
Permet à un serveur CAS d'utiliser esup-smsu-api pour envoyer des SMS.

Avec ça, on peut proposer une authentifcation MFA via SMS dans CAS uniquement par configuration (sans ajouter/coder un plugin CAS supplémentaire), ce avec une configuration de la sorte dans cas.properties : 
`` 
# Récupération du numéro de mobile depuis ldap pour le mfa-simple au travers duquel on utilise ESUP-SMSU
cas.authn.attributeRepository.ldap[0].attributes.mobile = mobile

##############################                                                                                                                                                              
## ESUP-SMSU                ##                                                                                                                                                              
##############################                                                                                                                                                              
cas.smsProvider.rest.url=https://esup-smsu-api.univ-ville.fr/apereo-cas                                                                                                                      
cas.smsProvider.rest.basicAuthUsername=smsu4cas
cas.smsProvider.rest.basicAuthPassword=motDePasse


##############################                                                                                                                                                              
## MFA                      ##                                                                                                                                                              
##############################                                                                                                                                                              
# Activate MFA globally for all, regardless of other settings                                                                                                                               
cas.authn.mfa.globalProviderId=mfa-simple

cas.authn.mfa.simple.name=sms
cas.authn.mfa.simple.order=0
cas.authn.mfa.simple.timeToKillInSeconds=300

cas.authn.mfa.simple.sms.from=Esup-SMSU (non utilisé)
cas.authn.mfa.simple.sms.text=Bonjour, voici le code SMS (token) requis pour réaliser votre authentification CAS : %s
cas.authn.mfa.simple.sms.attributeName=mobile
`` 

Ne pas oublier de mettre dans le build.gradle de CAS :
``
compile "org.apereo.cas:cas-server-support-simple-mfa:${project.'cas.version'}"
``  