### PR TITLE
Add index to optimise check if sms already sent

### DIFF
--- a/src/main/resources/database/migrate_indexes.sql
+++ b/src/main/resources/database/migrate_indexes.sql
@@ -1,0 +1,1 @@
+create index idx_check on sms (sms_initial_id, sms_phone);


### PR DESCRIPTION
Ajout d'un index sur le couple (sms_initial_id, sms_phone) suite à l'observation d'une lenteur lors de l'envoi d'un grand nombre de sms.
De notre côté, le test a été fait avec 7000 sms : ~15 minutes sans index contre 1 minute avec.
Une autre optimisation possible est de réduire le nombre de select qui sont faits lors de la vérification qui permet de ne pas renvoyer le même sms.
Il s'agit de vérifier si le msgId existe déjà avant de vérifier pour chaque numéro de téléphone dans SendSmsManager.saveSMS() 
```
if (!daoService.getSms(app, msgId).isEmpty()) {
if (msgId != null && app != null) {
            for (String smsPhone : smsPhones) {
                            if (!daoService.getSms(app, msgId, smsPhone).isEmpty()) {
                                String msg = "SMS already sent! Check for a problem with the application : " + app.getName();
                                logger.error(msg);
                                throw new AlreadySentException(msg);
                            }
             }
}
}
```
Et de créer la méthode correspondante dans daoService.